### PR TITLE
Lock Arcgis Version

### DIFF
--- a/arcgis_map_sdk/pubspec.yaml
+++ b/arcgis_map_sdk/pubspec.yaml
@@ -2,7 +2,7 @@ name: arcgis_map_sdk
 description: Esri ArcGIS map for Flutter for Web, iOS and Android platforms
 version: 0.8.0
 repository: https://github.com/fluttercommunity/arcgis_map_sdk
-maintainer: Matthaios Saitakis (@MatthaiosSait), Stefan Schaller (@stefanschaller), Julian Bissekkou (@JulianBissekkou), 
+maintainer: Matthaios Saitakis (@MatthaiosSait), Stefan Schaller (@stefanschaller), Julian Bissekkou (@JulianBissekkou),
   Pascal Welsch (@passsy), Max Peters (@maxpeters)
 
 environment:
@@ -10,8 +10,8 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  arcgis_map_sdk_android: 0.8.0
-  arcgis_map_sdk_ios: 0.8.0
+  arcgis_map_sdk_android: ^0.8.0
+  arcgis_map_sdk_ios: ^0.8.0
   arcgis_map_sdk_platform_interface: ^1.0.1
   # todo: this was removed to make sure we don't end up with web artifacts in our mobile build
   # this is only a temporary solution.

--- a/arcgis_map_sdk/pubspec.yaml
+++ b/arcgis_map_sdk/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  arcgis_map_sdk_android: ^0.8.0
-  arcgis_map_sdk_ios: ^0.8.0
+  arcgis_map_sdk_android: 0.8.0
+  arcgis_map_sdk_ios: 0.8.0
   arcgis_map_sdk_platform_interface: ^1.0.1
   # todo: this was removed to make sure we don't end up with web artifacts in our mobile build
   # this is only a temporary solution.

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -14,6 +14,7 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.dependency 'ArcGIS-Runtime-SDK-iOS', '100.15.1'
   s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.1'
   s.platform = :ios, '13.0'
 

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -15,7 +15,6 @@ A new Flutter project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.1'
-  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '~> 100.15.1'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -15,6 +15,7 @@ A new Flutter project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.1'
+  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '~> 100.15.1'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -14,7 +14,7 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.0'
+  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.1'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -14,7 +14,6 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ArcGIS-Runtime-SDK-iOS', '100.15.1'
   s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.1'
   s.platform = :ios, '13.0'
 

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -14,7 +14,7 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ArcGIS-Runtime-Toolkit-iOS'
+  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.2'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -14,7 +14,7 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.2'
+  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.1'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
+++ b/arcgis_map_sdk_ios/ios/arcgis_map_sdk_ios.podspec
@@ -14,7 +14,7 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.1'
+  s.dependency 'ArcGIS-Runtime-Toolkit-iOS', '100.15.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -30,6 +30,8 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
+  
+  pod 'ArcGIS-Runtime-SDK-iOS', '100.10.1'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -30,8 +30,6 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-  
-  pod 'ArcGIS-Runtime-SDK-iOS', '100.10.1'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end


### PR DESCRIPTION
after `pod install --repo-update` the map did not work and the MapController exposes the state MapStatus.error. Quick fix is to lock the version of the dependency and in the next step the issue must be fixed.